### PR TITLE
Checking the relative usage of mapped column with annotation type

### DIFF
--- a/src/sgchemist/orm/field.py
+++ b/src/sgchemist/orm/field.py
@@ -64,7 +64,11 @@ class AbstractField(Generic[T]):
             """Return the value of the field."""
 
 
-class NumericField(AbstractField[T]):
+class AbstractValueField(AbstractField[T]):
+    """Definition of an abstract value field."""
+
+
+class NumericField(AbstractValueField[T]):
     """Definition of an abstract numerical field."""
 
     cast_type: Type[T]
@@ -162,7 +166,7 @@ class FloatField(NumericField[Optional[float]]):
     default_value: Optional[float] = None
 
 
-class TextField(AbstractField[Optional[str]]):
+class TextField(AbstractValueField[Optional[str]]):
     """A text field."""
 
     cast_type: Type[str] = str
@@ -352,7 +356,7 @@ class MultiEntityField(AbstractEntityField[List[T]]):
     default_value: List[T] = []
 
 
-class BooleanField(AbstractField[Optional[bool]]):
+class BooleanField(AbstractValueField[Optional[bool]]):
     """Definition a boolean field."""
 
     __sg_type__: str = "checkbox"
@@ -487,7 +491,7 @@ class DurationField(NumberField):
     __sg_type__: str = "duration"
 
 
-class ImageField(AbstractField[Optional[str]]):
+class ImageField(AbstractValueField[Optional[str]]):
     """Definition of an image field."""
 
     cast_type: Type[str] = str
@@ -515,7 +519,7 @@ class ImageField(AbstractField[Optional[str]]):
             """
 
 
-class ListField(AbstractField[Optional[List[str]]]):
+class ListField(AbstractValueField[Optional[List[str]]]):
     """Definition of a list field."""
 
     cast_type: Type[List[str]] = list
@@ -555,7 +559,7 @@ class PercentField(FloatField):
     __sg_type__: str = "percent"
 
 
-class SerializableField(AbstractField[Optional[Dict[str, Any]]]):
+class SerializableField(AbstractValueField[Optional[Dict[str, Any]]]):
     """Definition of a serializable field."""
 
     cast_type: Type[Dict[str, Any]] = dict
@@ -563,14 +567,14 @@ class SerializableField(AbstractField[Optional[Dict[str, Any]]]):
     default_value: Optional[Dict[str, Any]] = None
 
 
-class StatusField(AbstractField[str]):
+class StatusField(AbstractValueField[str]):
     """Definition of a status field."""
 
     __sg_type__: str = "status_list"
     default_value: str
 
 
-class UrlField(AbstractField[Optional[str]]):
+class UrlField(AbstractValueField[Optional[str]]):
     """Definition of an url field."""
 
     cast_type: Type[str] = str

--- a/src/sgchemist/orm/mapped_column.py
+++ b/src/sgchemist/orm/mapped_column.py
@@ -14,7 +14,9 @@ from typing import Type
 from typing import TypeVar
 
 from sgchemist.orm import error
+from sgchemist.orm.field import AbstractEntityField
 from sgchemist.orm.field import AbstractField
+from sgchemist.orm.field import AbstractValueField
 from sgchemist.orm.field import EntityField
 from sgchemist.orm.field import MultiEntityField
 from sgchemist.orm.instrumentation import InstrumentedAttribute
@@ -158,6 +160,10 @@ class MappedField(MappedColumn):
         Returns:
             InstrumentedField[T]: the instrumented field
         """
+        if not issubclass(field_annotation.field_type, AbstractValueField):
+            raise error.SgInvalidAnnotation(
+                "A MappedField should target an AbstractValueField annotation"
+            )
         return InstrumentedField(
             class_=field_annotation.entity_class,
             field_annotation=field_annotation,
@@ -195,6 +201,10 @@ class Relationship(MappedColumn):
         container_class = field_annotation.container_class
         entity_class = field_annotation.entity_class
         # Make some checks
+        if not issubclass(field_annotation.field_type, AbstractEntityField):
+            raise error.SgInvalidAnnotation(
+                "A Relationship should target an AbstractEntityField annotation"
+            )
         if len(entities) == 0:
             raise error.SgInvalidAnnotation(
                 "An entity field must provide a target entity"

--- a/src/sgchemist/schema/generate_entities.py
+++ b/src/sgchemist/schema/generate_entities.py
@@ -80,7 +80,9 @@ def generate_python_script_field(
         default_str = f'"{default}"' if isinstance(default, str) else f"{default}"
         field_args.append(f"default={default_str}")
     field_column_factory = (
-        "relationship" if issubclass(field_type, MultiEntityField) else "mapped_field"
+        "relationship"
+        if issubclass(field_type, AbstractEntityField)
+        else "mapped_field"
     )
     fields_instructions = [
         f"{field_schema.field_name}: {annotation} = "
@@ -260,7 +262,7 @@ You can then pass these files to sg2python to create the python script.
         type=str,
         nargs="+",
         help="skip the field if <EntityType>.<field_name> matches any of the given "
-             "regex",
+        "regex",
     )
     parser.add_argument(
         "--skip-entities",
@@ -273,9 +275,9 @@ You can then pass these files to sg2python to create the python script.
         action="store_true",
         default=False,
         help="do not generate classes for the connection tables. "
-             "Shotgrid uses these tables to create the many to many relationships. "
-             "Because sgchemist can create these relationships without an intermediate "
-             "class, this is disabled by default.",
+        "Shotgrid uses these tables to create the many to many relationships. "
+        "Because sgchemist can create these relationships without an intermediate "
+        "class, this is disabled by default.",
     )
     return parser
 

--- a/tests/test_orm/test_entity.py
+++ b/tests/test_orm/test_entity.py
@@ -15,11 +15,12 @@ from classes import Project
 from classes import Shot
 from classes import Task
 from sgchemist.orm import error
-from sgchemist.orm.entity import SgEntity
-from sgchemist.orm.field import EntityField
-from sgchemist.orm.field import MultiEntityField
-from sgchemist.orm.field import NumberField
-from sgchemist.orm.field import TextField
+from sgchemist.orm import mapped_field
+from sgchemist.orm import SgEntity
+from sgchemist.orm import EntityField
+from sgchemist.orm import MultiEntityField
+from sgchemist.orm import NumberField
+from sgchemist.orm import TextField
 from sgchemist.orm.instrumentation import InstrumentedField
 from sgchemist.orm.instrumentation import InstrumentedMultiTargetSingleRelationship
 from sgchemist.orm.mapped_column import alias_relationship
@@ -145,6 +146,27 @@ def test_undefined_fields():
         class _TestEntity3(SgEntity):
             __sg_type__ = "test2"
             entity: TestEntity
+
+
+def test_right_mapped_field_per_annotation():
+    """Tests the correct MappedColumn object is used for a given annotation."""
+    with pytest.raises(error.SgEntityClassDefinitionError):
+
+        class _TestEntity1(SgEntity):
+            __sg_type__ = "test"
+            field: TextField = relationship()
+
+    with pytest.raises(error.SgEntityClassDefinitionError):
+
+        class _TestEntity2(SgEntity):
+            __sg_type__ = "test"
+            field: EntityField[_TestEntity2] = mapped_field()
+
+    with pytest.raises(error.SgEntityClassDefinitionError):
+
+        class _TestEntity3(SgEntity):
+            __sg_type__ = "test"
+            field: MultiEntityField[_TestEntity2] = mapped_field()
 
 
 def test_union_entity_is_multi_target():


### PR DESCRIPTION
Using a `mapped_field` to describe an `EntityField` is left possible.
Same with `relationship` and common value field like `TextField`.

This PR adds a layer of safety to ensure user uses a the correct `MappedColumn` with respect to the `AbstractField` used for annotation.