### PR TITLE
move field information and casting to dunders for clarity

### DIFF
--- a/src/sgchemist/orm/annotation.py
+++ b/src/sgchemist/orm/annotation.py
@@ -6,10 +6,8 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Collection
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
@@ -84,7 +82,7 @@ class LazyEntityCollectionClassEval:
         """Return all the evaluated entity classes.
 
         Returns:
-            list[Type[SgEntity]]: list of entity classes
+            tuple[Type[SgEntity]]: list of entity classes
         """
         self._fill()
         return list(self._resolved_by_name.values())
@@ -96,4 +94,3 @@ class FieldAnnotation:
 
     field_type: Type[AbstractField[Any]]
     entities: Tuple[str, ...]
-    container_class: Optional[Type[Collection[Any]]]

--- a/src/sgchemist/orm/engine.py
+++ b/src/sgchemist/orm/engine.py
@@ -90,10 +90,11 @@ class ShotgunAPIEngine(SgEngine):
         """
         model = query.model
         field_by_name = {
-            field.get_name(): field for field in query.fields + query.loading_fields
+            field.__info__.field_name: field
+            for field in query.fields + query.loading_fields
         }
         orders = [
-            {"field_name": field.get_name(), "direction": direction.value}
+            {"field_name": field.__info__.field_name, "direction": direction.value}
             for field, direction in query.order_fields
         ]
         condition = query.condition
@@ -120,7 +121,7 @@ class ShotgunAPIEngine(SgEngine):
                     continue
                 field = field_by_name[column_name]
                 column_value = (
-                    field.cast_value_over(_cast_record, column_value)
+                    field.__cast__.cast_value_over(_cast_record, column_value)
                     if column_value is not None
                     else column_value
                 )
@@ -131,7 +132,7 @@ class ShotgunAPIEngine(SgEngine):
             rows.append(_cast_record(record))
         # Reorganize the row contents
         for field in query.loading_fields:
-            key = field.get_name()
+            key = field.__info__.field_name
             column_name, entity_type, target_key = key.split(".")
             for row in rows:
                 row.content[column_name].content[target_key] = row.content.pop(key)

--- a/src/sgchemist/orm/entity.py
+++ b/src/sgchemist/orm/entity.py
@@ -35,7 +35,7 @@ class SgEntity(metaclass=SgEntityMeta):
     __state__: ClassVar[EntityState]
 
     id: NumberField = NumberField(name="id")
-    id._primary = True
+    id.__info__.primary = True
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Adds the subclass to the global entity registry."""
@@ -58,7 +58,7 @@ class SgEntity(metaclass=SgEntityMeta):
         self.__state__ = EntityState(self)
         # Init with field default value by setting its state
         for field in self.__fields__.values():
-            self.__state__.get_slot(field).value = field.get_default_value()
+            self.__state__.get_slot(field).value = field.__info__.default_value
         # Set with keyword arguments
         for k, v in kwargs.items():
             field = self.__fields__.get(k)
@@ -67,7 +67,7 @@ class SgEntity(metaclass=SgEntityMeta):
                     f"{self.__class__.__name__} has no field {k}"
                 )
 
-            if field.is_primary():
+            if field.__info__.primary:
                 self.__state__.get_slot(field).value = v
             else:
                 setattr(self, k, v)
@@ -79,7 +79,7 @@ class SgEntity(metaclass=SgEntityMeta):
             str: representation of the entity.
         """
         primary_fields = {
-            field.get_name(): getattr(self, attr_name)
+            field.__info__.field_name: getattr(self, attr_name)
             for attr_name, field in self.__fields__.items()
             if attr_name in self.__primaries__
         }

--- a/src/sgchemist/orm/query.py
+++ b/src/sgchemist/orm/query.py
@@ -185,14 +185,14 @@ class SgFindQuery(Generic[T_meta]):
         # Check the given fields belongs to the relationships of the queried fields
         new_state = dataclasses.replace(self._data)
         queried_relationship_paths = {
-            f.get_hash()
+            f.__info__.get_hash()
             for f in new_state.fields
-            if isinstance(f, AbstractEntityField) and not f.is_alias()
+            if isinstance(f, AbstractEntityField) and not f.__info__.is_alias()
         }
         for field in fields:
-            if field.is_primary():
+            if field.__info__.primary:
                 continue
-            if field.get_hash()[:-1] not in queried_relationship_paths:
+            if field.__info__.get_hash()[:-1] not in queried_relationship_paths:
                 raise error.SgQueryError(
                     f"Cannot load {field} because its entity is not queried."
                 )
@@ -207,12 +207,13 @@ class SgFindQuery(Generic[T_meta]):
             relationship_fields = tuple(
                 field
                 for field in self.get_data().fields
-                if isinstance(field, AbstractEntityField) and not field.is_alias()
+                if isinstance(field, AbstractEntityField)
+                and not field.__info__.is_alias()
             )
         # Construct all the fields for the relationships
         all_fields = []
         for field in relationship_fields:
-            for target_type in field.get_types():
+            for target_type in field.__cast__.get_types():
                 for target_field in target_type.__fields__.values():
                     all_fields.append(field.f(target_field))
         return self.load(*all_fields)

--- a/src/sgchemist/orm/serializer.py
+++ b/src/sgchemist/orm/serializer.py
@@ -52,7 +52,7 @@ def serialize_condition(condition: SgFieldCondition) -> SerializedCondition:
     if isinstance(condition.right, SgEntity):
         right = serialize_entity(condition.right)
     return [
-        condition.field.get_name(),
+        condition.field.__info__.field_name,
         condition.operator.value,
         right,
     ]
@@ -150,7 +150,7 @@ class ShotgunAPIBatchQuerySerializer:
                     "type": value.__sg_type__,
                     "id": value.id,
                 }
-            model_data[field.get_name()] = value
+            model_data[field.__info__.field_name] = value
         model_data.pop("id", None)
         return model_data
 

--- a/src/sgchemist/orm/session.py
+++ b/src/sgchemist/orm/session.py
@@ -158,7 +158,7 @@ class Session:
             # from relationship.
             # We construct a new field mapper in this case
             field_mapper = {
-                field.get_name_in_relation(): field_mapper[field.get_name()]
+                field.__info__.name_in_relation: field_mapper[field.__info__.field_name]
                 for field in entity_cls.__fields__.values()
             }
 
@@ -169,7 +169,9 @@ class Session:
         for attr_name, column_value in column_value_by_attr.items():
             field = entity_cls.__fields__[attr_name]
             # Cast column value
-            column_value = field.cast_column(column_value, self._get_or_create_instance)
+            column_value = field.__cast__.cast_column(
+                column_value, self._get_or_create_instance
+            )
             inst_data[attr_name] = column_value
 
         inst = entity_cls(**inst_data)
@@ -249,7 +251,9 @@ class Session:
         # Add modified relationships in cascade
         for field in entity.__fields__.values():
             rel_value = state.get_slot(field).value
-            for field_entity in field.iter_entities_from_field_value(rel_value):
+            for field_entity in field.__cast__.iter_entities_from_field_value(
+                rel_value
+            ):
                 self._check_relationship_commited(field_entity)
 
         query = SgBatchQuery(request_type, entity)
@@ -307,7 +311,7 @@ class Session:
             for field_name, field_value in row.content.items():
                 # Do not set the relationship field
                 field = original_model.__fields__[field_mapper[field_name]]
-                field.update_entity_from_row_value(original_model, field_value)
+                field.__cast__.update_entity_from_row_value(original_model, field_value)
             # The entity has now an unmodified state
             state.set_as_original()
             state.pending_add = False

--- a/tests/test_orm/test_field.py
+++ b/tests/test_orm/test_field.py
@@ -68,8 +68,8 @@ def test_lazy_entity_collection_eval(
     "field, exp_name, exp_class, exp_default, exp_primary, "
     "exp_name_in_rel, exp_types",
     [
-        (Shot.name, "code", Shot, None, False, "name", (str,)),
-        (Shot.id, "id", Shot, None, True, "id", (int,)),
+        (Shot.name, "code", Shot, None, False, "name", tuple()),
+        (Shot.id, "id", Shot, None, True, "id", tuple()),
         (Shot.project, "project", Shot, None, False, "project", (Project,)),
         (
             Shot.parent_shots,
@@ -94,12 +94,12 @@ def test_field_attributes(
 ) -> None:
     """Tests the fields attributes."""
     assert isinstance(repr(field), str)
-    assert field.get_name() == exp_name
-    assert field.get_parent_class() is exp_class
-    assert field.get_default_value() == exp_default
-    assert not field.is_alias()
-    assert field.get_name_in_relation() == exp_name_in_rel
-    assert set(field.get_types()) == set(exp_types)
+    assert field.__info__.field_name == exp_name
+    assert field.__info__.entity is exp_class
+    assert field.__info__.default_value == exp_default
+    assert not field.__info__.is_alias()
+    assert field.__info__.name_in_relation == exp_name_in_rel
+    assert set(field.__cast__.get_types()) == set(exp_types)
 
 
 @pytest.mark.parametrize(
@@ -116,7 +116,7 @@ def test_field_attributes(
 )
 def test_build_relative_to(field: AbstractField[Any], exp_field_name: str) -> None:
     """Tests the relative field names."""
-    assert field.get_name() == exp_field_name
+    assert field.__info__.field_name == exp_field_name
 
 
 def test_missing_attribute_on_target_selector() -> None:
@@ -149,8 +149,8 @@ def test_update_entity_from_row_value(
     field: AbstractField[Any], value_to_set: Any, exp_value: Any
 ) -> None:
     """Tests the update entity from row attribute."""
-    inst = field.get_parent_class()()
-    field.update_entity_from_row_value(inst, value_to_set)
+    inst = field.__info__.entity()
+    field.__cast__.update_entity_from_row_value(inst, value_to_set)
     assert inst.__state__.get_slot(field).value == exp_value
 
 
@@ -170,7 +170,7 @@ def test_entities_iter_entities_from_field_values(
     field: AbstractField[Any], value: Any, exp_value: Any
 ) -> None:
     """Tests the entity iterator."""
-    assert list(field.iter_entities_from_field_value(value)) == exp_value
+    assert list(field.__cast__.iter_entities_from_field_value(value)) == exp_value
 
 
 @pytest.mark.parametrize(
@@ -189,7 +189,7 @@ def test_cast_value_over(
     exp_value: Any,
 ) -> None:
     """Tests the cast value over method."""
-    assert field.cast_value_over(func, value) == exp_value
+    assert field.__cast__.cast_value_over(func, value) == exp_value
 
 
 @pytest.mark.parametrize(
@@ -216,7 +216,7 @@ def test_cast_column(
     exp_value: Any,
 ) -> None:
     """Tests the cast column method."""
-    assert field.cast_column(value, func) == exp_value
+    assert field.__cast__.cast_column(value, func) == exp_value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Put information and casting logic outside of the field classes.
This makes the use of fields easier.